### PR TITLE
Reorder import statements in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ from core_helpers import (
 
 warnings.filterwarnings(
     "ignore",
-import warnings
+)
 import time
 import random
 


### PR DESCRIPTION
Moved the import statement for warnings to the top of the file.